### PR TITLE
Add release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,5 +105,5 @@ workflows:
             - test-ruby25
             - test-ruby26
             - test-ruby27
-            - jruby
-            - jruby92
+            - test-jruby
+            - test-jruby92

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,17 +20,6 @@ executors:
     environment:
       JRUBY_OPTS: "--debug"
 
-step_bundle_install: &step_bundle_install
-  run:
-    name: Install gem dependencies
-    command: bundle install
-filters_only_release_tags: &filters_only_release_tags
-  filters:
-    branches:
-      ignore: /.*/
-    tags:
-      only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
-
 commands:
   rake-test:
     steps:
@@ -72,7 +61,9 @@ jobs:
           command: |
             apt-get -y -qq update
             apt-get -y -qq install awscli
-      - *step_bundle_install
+      - run:
+          name: Install gem dependencies
+          command: bundle install
       - run:
           name: Upload release Gem and rebuild index
           command: S3_DIR=otel-release bundle exec rake release:gem
@@ -105,10 +96,14 @@ workflows:
             tags:
               only: /^opentelemetry-.+\/v\d.*$/
       - "deploy release":
-        <<: *filters_only_release_tags
-        requires:
-          - test-ruby25
-          - test-ruby26
-          - test-ruby27
-          - jruby
-          - jruby92
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/        
+          requires:
+            - test-ruby25
+            - test-ruby26
+            - test-ruby27
+            - jruby
+            - jruby92

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,15 +95,15 @@ workflows:
           filters:
             tags:
               only: /^opentelemetry-.+\/v\d.*$/
-      - "deploy release":
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/        
-          requires:
-            - test-ruby25
-            - test-ruby26
-            - test-ruby27
-            - test-jruby
-            - test-jruby92
+      # - "deploy release":
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/        
+      #     requires:
+      #       - test-ruby25
+      #       - test-ruby26
+      #       - test-ruby27
+      #       - test-jruby
+      #       - test-jruby92

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,18 @@ executors:
       - image: "circleci/jruby:9.2.8-jre"
     environment:
       JRUBY_OPTS: "--debug"
+
+step_bundle_install: &step_bundle_install
+  run:
+    name: Install gem dependencies
+    command: bundle install
+filters_only_release_tags: &filters_only_release_tags
+  filters:
+    branches:
+      ignore: /.*/
+    tags:
+      only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
+
 commands:
   rake-test:
     steps:
@@ -29,6 +41,7 @@ commands:
       - run:
           name: CI (Datadog)
           command: "bundle exec rake"
+
 jobs:
   test-ruby25:
     executor: ruby25
@@ -50,6 +63,23 @@ jobs:
     executor: jruby92
     steps:
       - rake-test
+  "deploy release":
+    executor: ruby27
+    steps:
+      - checkout
+      - run:
+          name: Install AWS CLI
+          command: |
+            apt-get -y -qq update
+            apt-get -y -qq install awscli
+      - *step_bundle_install
+      - run:
+          name: Upload release Gem and rebuild index
+          command: S3_DIR=otel-release bundle exec rake release:gem
+      - store_artifacts:
+          path: pkg/
+          destination: gem
+
 workflows:
   version: 2
   builds:
@@ -74,3 +104,11 @@ workflows:
           filters:
             tags:
               only: /^opentelemetry-.+\/v\d.*$/
+      - "deploy release":
+        <<: *filters_only_release_tags
+        requires:
+          - test-ruby25
+          - test-ruby26
+          - test-ruby27
+          - jruby
+          - jruby92

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,12 @@
 # Release History: opentelemetry-exporters-datadog
+
+## [Unreleased]
+
+### Added
+- initial release
+- add DatadogSpanProcessor
+- add DatadogExporter
+- add DatadogProbabilitySampler
+- add DatadogPropagator
+- add setup and usage instructions
+- add unit tests

--- a/README.md
+++ b/README.md
@@ -160,6 +160,5 @@ The `opentelemetry-exporters-datadog` gem is distributed under the Apache 2.0 li
 [datadog-home]: https://www.datadoghq.com
 [opentelemetry-home]: https://opentelemetry.io
 [bundler-home]: https://bundler.io
-[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
 [license-github]: https://github.com/DataDog/dd-opentelemetry-exporter-ruby/blob/master/LICENSE
 [examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/master/examples

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**[WARNING, THIS PROJECT IS EXPERIMENTAL AND UNDER ACTIVE DEVELOPMENT]**
+**[BETA]**
 
 # opentelemetry-exporters-datadog
 
@@ -152,12 +152,6 @@ This enables you to set this value on a per application basis, so you can have f
 
 Tags can also be set directly on individual spans, which will supersede any conflicting tags defined at the application level.
 
-## How can I get involved?
-
-The `opentelemetry-exporters-datadog` gem source is [on github][repo-github], along with related gems including `opentelemetry-sdk`.
-
-The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
-
 ## License
 
 The `opentelemetry-exporter-datadog` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
@@ -167,8 +161,5 @@ The `opentelemetry-exporter-datadog` gem is distributed under the Apache 2.0 lic
 [opentelemetry-home]: https://opentelemetry.io
 [bundler-home]: https://bundler.io
 [repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
-[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[license-github]: https://github.com/DataDog/dd-opentelemetry-exporter-ruby/blob/master/LICENSE
 [examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/master/examples
-[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
-[community-meetings]: https://github.com/open-telemetry/community#community-meetings
-[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Generally, *libraries* that produce telemetry data should avoid depending direct
 - If you use [bundler][bundler-home], include the following in your `Gemfile`:
 
 ```
-gem 'opentelemetry-exporters-datadog', git: 'https://github.com/Datadog/dd-opentelemetry-exporter-ruby'
+gem 'opentelemetry-exporters-datadog'
 gem 'opentelemetry-api', '~> 0.5'
 gem 'opentelemetry-sdk', '~> 0.5'
 ```
@@ -154,7 +154,7 @@ Tags can also be set directly on individual spans, which will supersede any conf
 
 ## License
 
-The `opentelemetry-exporter-datadog` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+The `opentelemetry-exporters-datadog` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
 
 
 [datadog-home]: https://www.datadoghq.com

--- a/Rakefile
+++ b/Rakefile
@@ -34,15 +34,16 @@ end
 #       require './lib/opentelemetry/exporters/datadog/version.rb'
 #       OpenTelemetry::Exporters::Datadog::VERSION
 #     }
-#   }	
+#   }
 # }
 
 # Deploy tasks
-S3_BUCKET = 'gems.datadoghq.com'.freeze
+S3_BUCKET = 'gems.datadoghq.com'
 S3_DIR = ENV['S3_DIR']
 
 task :'release:gem' do
   raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
+
   # load existing deployed gems
   sh "aws s3 cp --exclude 'docs/*' --recursive s3://#{S3_BUCKET}/#{S3_DIR}/ ./rubygems/"
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,3 +27,44 @@ if RUBY_ENGINE == 'truffleruby'
 else
   task default: %i[test rubocop yard]
 end
+
+# GEM_INFO = {
+#   "opentelemetry-exporters-datadog" => {
+#     version_getter: ->() {
+#       require './lib/opentelemetry/exporters/datadog/version.rb'
+#       OpenTelemetry::Exporters::Datadog::VERSION
+#     }
+#   }	
+# }
+
+# Deploy tasks
+S3_BUCKET = 'gems.datadoghq.com'.freeze
+S3_DIR = ENV['S3_DIR']
+
+task :'release:gem' do
+  raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
+  # load existing deployed gems
+  sh "aws s3 cp --exclude 'docs/*' --recursive s3://#{S3_BUCKET}/#{S3_DIR}/ ./rubygems/"
+
+  # create folders
+  sh 'mkdir -p ./gems'
+  sh 'mkdir -p ./rubygems/gems'
+
+  # build the gem
+  Rake::Task['build'].execute
+
+  # copy the output in the indexed folder
+  sh 'cp pkg/*.gem ./rubygems/gems/'
+
+  # generate the gems index
+  sh 'gem generate_index -v --no-modern -d ./rubygems'
+
+  # remove all local repository gems to limit files needed to be uploaded
+  sh 'rm -f ./rubygems/gems/*'
+
+  # re-add new gems
+  sh 'cp pkg/*.gem ./rubygems/gems/'
+
+  # deploy a static gem registry
+  sh "aws s3 cp --recursive ./rubygems/ s3://#{S3_BUCKET}/#{S3_DIR}/"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -28,35 +28,35 @@ else
   task default: %i[test rubocop yard]
 end
 
-# Deploy tasks
-S3_BUCKET = 'gems.datadoghq.com'
-S3_DIR = ENV['S3_DIR']
+# # Deploy tasks
+# S3_BUCKET = 'gems.datadoghq.com'
+# S3_DIR = ENV['S3_DIR']
 
-task :'release:gem' do
-  raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
+# task :'release:gem' do
+#   raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
 
-  # load existing deployed gems
-  sh "aws s3 cp --exclude 'docs/*' --recursive s3://#{S3_BUCKET}/#{S3_DIR}/ ./rubygems/"
+#   # load existing deployed gems
+#   sh "aws s3 cp --exclude 'docs/*' --recursive s3://#{S3_BUCKET}/#{S3_DIR}/ ./rubygems/"
 
-  # create folders
-  sh 'mkdir -p ./gems'
-  sh 'mkdir -p ./rubygems/gems'
+#   # create folders
+#   sh 'mkdir -p ./gems'
+#   sh 'mkdir -p ./rubygems/gems'
 
-  # build the gem
-  Rake::Task['build'].execute
+#   # build the gem
+#   Rake::Task['build'].execute
 
-  # copy the output in the indexed folder
-  sh 'cp pkg/*.gem ./rubygems/gems/'
+#   # copy the output in the indexed folder
+#   sh 'cp pkg/*.gem ./rubygems/gems/'
 
-  # generate the gems index
-  sh 'gem generate_index -v --no-modern -d ./rubygems'
+#   # generate the gems index
+#   sh 'gem generate_index -v --no-modern -d ./rubygems'
 
-  # remove all local repository gems to limit files needed to be uploaded
-  sh 'rm -f ./rubygems/gems/*'
+#   # remove all local repository gems to limit files needed to be uploaded
+#   sh 'rm -f ./rubygems/gems/*'
 
-  # re-add new gems
-  sh 'cp pkg/*.gem ./rubygems/gems/'
+#   # re-add new gems
+#   sh 'cp pkg/*.gem ./rubygems/gems/'
 
-  # deploy a static gem registry
-  sh "aws s3 cp --recursive ./rubygems/ s3://#{S3_BUCKET}/#{S3_DIR}/"
-end
+#   # deploy a static gem registry
+#   sh "aws s3 cp --recursive ./rubygems/ s3://#{S3_BUCKET}/#{S3_DIR}/"
+# end

--- a/Rakefile
+++ b/Rakefile
@@ -28,15 +28,6 @@ else
   task default: %i[test rubocop yard]
 end
 
-# GEM_INFO = {
-#   "opentelemetry-exporters-datadog" => {
-#     version_getter: ->() {
-#       require './lib/opentelemetry/exporters/datadog/version.rb'
-#       OpenTelemetry::Exporters::Datadog::VERSION
-#     }
-#   }
-# }
-
 # Deploy tasks
 S3_BUCKET = 'gems.datadoghq.com'
 S3_DIR = ENV['S3_DIR']

--- a/opentelemetry-exporters-datadog.gemspec
+++ b/opentelemetry-exporters-datadog.gemspec
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'ddtrace', '~> 0.37'
-  spec.add_dependency 'opentelemetry-api', '~> 0.4'
-  spec.add_dependency 'opentelemetry-sdk', '~> 0.4'
+  spec.add_dependency 'opentelemetry-api', '~> 0.5'
+  spec.add_dependency 'opentelemetry-sdk', '~> 0.5'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'


### PR DESCRIPTION
- Adds circleci job for releasing
- Adds rake tasks for handling gem release

TODOs:
 - get some validation on whether this approach is appropriate (or what's missing)
 - validate s3 dir naming convention and how to manage private rubgems api keys