### PR TITLE
release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History: opentelemetry-exporters-datadog
 
-## [0.2.1] - 2022-03-10
+## [0.2.2] - 2022-03-10
 
 ### Added
 - deprecate opentelemetry-exporters-datadog gem

--- a/lib/opentelemetry/exporters/datadog/version.rb
+++ b/lib/opentelemetry/exporters/datadog/version.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
   module Exporters
     module Datadog
       ## Current OpenTelemetry Datadog exporter version
-      VERSION = '0.2.1'
+      VERSION = '0.2.2'
     end
   end
 end


### PR DESCRIPTION
yanked 0.2.1 from rubygems, 0.2.2 will push out deprecation changes at a later date